### PR TITLE
Upgrading to nightlies for pytorch and drake; adding functionality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ Example demonstrating pytorch c++ integration with drake
 # Installation
 This repo provides two Dockerfiles, for CPU and GPU versions of pytorch.
 
-The CPU version uses standard, vanilla Docker; while the GPU version requires NVIDIA-docker. 
+The CPU version uses standard, vanilla Docker; while the GPU version requires NVIDIA-docker.
 
 ## NVIDIA-docker
-The host machine needs to have the same nvidia-driver and (possibly not?) CUDA version as the docker image. 
-The current version is built based on `nvidia-driver-410.48` and `cuda-10-0`. 
+The host machine needs to have the same nvidia-driver and (possibly not?) CUDA version as the docker image.
+The current version is built based on `nvidia-driver-410.48` and `cuda-10-0`.
 ### installing nvidia-driver
 ### installing CUDA 10.0
 ### installing cuDNN
 ### installing nvidia-docker
 
 # publishing drake-torch to docker hub
-(1) tag the new version both as `<type>_latest` and as `<type>_<date>` in `YYYYMMDD` format where `<type>` is `cuda` or `bionic`
+(1) tag the new version both as `<type>_latest` and as `<type>_<date>` in `YYYYMMDD` format where `<type>` is `cuda` or `cpu`
 
 `docker tag <commit> dexai2/drake-torch:cuda_latest`
 
@@ -25,11 +25,11 @@ and
 
 or
 
-`docker tag <commit> dexai2/drake-torch:bionic_latest`
+`docker tag <commit> dexai2/drake-torch:cpu_latest`
 
 and
 
-`docker tag <commit> dexai2/drake-torch:bionic_<date>`
+`docker tag <commit> dexai2/drake-torch:cpu_<date>`
 
 then, publish to docker hub
 

--- a/build.sh
+++ b/build.sh
@@ -1,24 +1,37 @@
 #!/bin/bash
-build_bionic () {
-    echo "building Ubuntu/bionic"
-    docker build -f drake-torch.dockerfile --build-arg BASE_IMAGE=ubuntu:bionic -t drake-torch:bionic --cpuset-cpus 0-4 .
+build_cpu () {
+    echo "building Ubuntu/cpu" > /dev/stderr
+    docker build -f drake-torch.dockerfile --no-cache --build-arg BASE_IMAGE=ubuntu:bionic --build-arg BUILD_TYPE=cpu -t drake-torch:cpu --cpuset-cpus 0-4 . > /dev/stderr
+    build_result=$? # debugging to see if function does the right thing
+    # echo "cpu_build_result = ${build_result}" > /dev/stderr
+    echo "${build_result}"
 }
 build_cuda () {
-    cuda_version=10.0
+    cuda_version=10.1
     cudnn_version=7
     ubuntu=18.04
-    echo "building nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel-ubuntu${ubuntu}"
-    docker build -f drake-torch.dockerfile --build-arg BASE_IMAGE=nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel-ubuntu${ubuntu} -t drake-torch:cuda --cpuset-cpus 0-4 .
+    # --no-cache
+    echo "building nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel-ubuntu${ubuntu}" > /dev/stderr
+    docker build -f drake-torch.dockerfile --no-cache --build-arg BUILD_TYPE=cuda --build-arg BASE_IMAGE=nvidia/cuda:${cuda_version}-cudnn${cudnn_version}-devel-ubuntu${ubuntu} -t drake-torch:cuda --cpuset-cpus 0-4 . > /dev/stderr
+    build_result=$?
+    echo "${build_result}"
 }
 if [[ $# -eq 0 ]]; then
     echo "no arguments supplied, defaulting to:"
-    build_bionic
-elif [[ $* == *--bionic* ]]; then
-    echo "Ubuntu/bionic specified:"
-    build_bionic
+    result=$(build_cpu)
+    echo "build_cpu returned: ${result}"
+    exit $result
+elif [[ $* == *--cpu* || $* == *--bionic* ]]; then
+    echo "Ubuntu/cpu specified:"
+    result=$(build_cpu)
+    echo "build_cpu returned: ${result}"
+    exit $result
 elif [[ $* == *--cuda* ]]; then
     echo "CUDA specified:"
-    build_cuda
+    result=$(build_cuda)
+    echo "build_cuda returned ${result}"
+    exit $result
 else
-    echo "need to specify --cuda --ubuntu (or no arguments, defaults to ubuntu/bionic)"
+    echo "need to specify --cuda --ubuntu (or no arguments, defaults to ubuntu/cpu)"
+    exit 1
 fi

--- a/build_test_dockers.sh
+++ b/build_test_dockers.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+build_cpu () {
+    echo "building drake-torch:cpu_test"
+    docker build --no-cache -f test_python.dockerfile --build-arg BASE_IMAGE=drake-torch:cpu -t drake-torch:cpu_test --cpuset-cpus 0-4 .
+}
+build_cuda () {
+    echo "building drake-torch:cuda_test"
+    docker build --no-cache -f test_python.dockerfile --build-arg BASE_IMAGE=drake-torch:cuda -t drake-torch:cuda_test --cpuset-cpus 0-4 .
+}
+if [[ $# -eq 0 ]]; then
+    echo "no arguments supplied, defaulting to both cpu and cuda:"
+    build_cpu
+    build_cuda
+elif [[ $* == *--cpu* || $* == *--bionic* ]]; then
+    echo "Ubuntu/cpu specified:"
+    build_cpu
+elif [[ $* == *--cuda* ]]; then
+    echo "CUDA specified:"
+    build_cuda
+else
+    echo "need to specify --cuda --ubuntu (or no arguments, defaults to both drake-torch:cpu and drake-torch:cuda)"
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,10 @@ services:
   gdbserver:
     build:
       context: .
-      args: 
+      args:
         - BASE_IMAGE=ubuntu:bionic
       dockerfile: drake-torch.dockerfile
-    image: dexai2/drake-torch:bionic_latest
+    image: dexai2/drake-torch:cpu_latest
     security_opt: # options needed for gdb debugging
       - seccomp:unconfined
       - apparmor:unconfined
@@ -15,7 +15,7 @@ services:
       - "7776:22"
       - "7777:7777"
       - "5920:5920"
-      - "8097:8097" 
+      - "8097:8097"
       - "8888:8888"
     environment:
-      - DISPLAY=":20" 
+      - DISPLAY=":20"

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -7,7 +7,7 @@ WORKDIR /root
 
 ARG BUILD_TYPE
 RUN echo "Oh dang look at that BUILD_TYPE=${BUILD_TYPE}"
-RUN echo "Oh dang look at that BUILD_TYPE=${BASE_IMAGE}"
+RUN echo "Oh dang look at that BASE_IMAGE=${BASE_IMAGE}"
 
 # Set debconf to noninteractive mode.
 # https://github.com/phusion/baseimage-docker/issues/58#issuecomment-47995343

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ubuntu:bionic
+ARG BASE_IMAGE
 FROM $BASE_IMAGE
 
 USER root
@@ -54,15 +54,17 @@ RUN set -eux \
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# download, build, install, and remove cmake-3.14.4
-RUN wget https://cmake.org/files/v3.14/cmake-3.14.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.4-Linux-x86_64.tar.gz \
-    && cp -r cmake-3.14.4-Linux-x86_64/bin /usr/ \
-    && cp -r cmake-3.14.4-Linux-x86_64/share /usr/ \
-    && cp -r cmake-3.14.4-Linux-x86_64/doc /usr/share/ \
-    && cp -r cmake-3.14.4-Linux-x86_64/man /usr/share/ \
-    && cd $HOME && rm -rf  cmake-3.14.4-Linux-x86_64.tar.gz \
-    && rm -rf cmake-3.14.4-Linux-x86_64
+# download, build, install, and remove cmake-3.17.1
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Linux-x86_64.tar.gz \
+    && wget https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-SHA-256.txt \
+    && cat cmake-3.17.1-SHA-256.txt | grep cmake-3.17.1-Linux-x86_64.tar.gz | sha256sum --check \
+    && tar -xzf cmake-3.17.1-Linux-x86_64.tar.gz \
+    && cp -r cmake-3.17.1-Linux-x86_64/bin /usr/ \
+    && cp -r cmake-3.17.1-Linux-x86_64/share /usr/ \
+    && cp -r cmake-3.17.1-Linux-x86_64/doc /usr/share/ \
+    && cp -r cmake-3.17.1-Linux-x86_64/man /usr/share/ \
+    && cd $HOME && rm -rf  cmake-3.17.1-Linux-x86_64.tar.gz \
+    && rm -rf cmake-3.17.1-Linux-x86_64
 
 # install the latest drake (dependencies and the binary)
 RUN set -eux \
@@ -94,25 +96,28 @@ RUN apt-get update && apt-get -y install intel-mkl-64bit-2019.1-053
 RUN rm /opt/intel/mkl/lib/intel64/*.so
 
 # Download and build libtorch with MKL support
-
 ENV TORCH_CUDA_ARCH_LIST="5.2 6.0 6.1 7.0 7.5"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV BUILD_CAFFE2_OPS=1
 ENV _GLIBCXX_USE_CXX11_ABI=1
-RUN git clone --recurse-submodules -j8 https://github.com/pytorch/pytorch.git
-RUN cd pytorch && mkdir build && cd build && BUILD_TEST=OFF USE_NCCL=OFF python3 ../tools/build_libtorch.py
 
+# CPU version
+RUN set -eux && cd $HOME \
+    && wget https://download.pytorch.org/libtorch/nightly/cpu/libtorch-cxx11-abi-shared-with-deps-latest.zip \
+    && unzip libtorch-cxx11-abi-shared-with-deps-latest.zip \
+    && mv libtorch /usr/local/lib/libtorch
+# install python pytorch and torchvision via pip
 RUN set -eux \
-    && cd $HOME/pytorch \
-    && python3 setup.py install \
-    && cd $HOME && rm -rf pytorch
+    && python3 -m pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
-# build torchvision from source
-RUN set -eux \
-    && cd $HOME && git clone https://github.com/pytorch/vision.git \
-    && cd vision \
-    && python3 setup.py install \
-    && cd $HOME && rm -rf vision
+# # CUDA version
+# RUN set -eux && cd $HOME \
+#    && wget https://download.pytorch.org/libtorch/nightly/cu101/libtorch-cxx11-abi-shared-with-deps-latest.zip \
+#    && unzip libtorch-cxx11-abi-shared-with-deps-latest.zip \
+#    && mv libtorch /usr/local/lib/libtorch
+# # install python pytorch and torchvision via pip
+# RUN set -eux \
+#    && python3 -m pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cu101/torch_nightly.html
 
 # setup keys
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
@@ -279,15 +284,17 @@ RUN apt-get update && apt-get install -y \
 RUN pip3 install --ignore-installed pyzmq
 RUN pip3 install jupyter
 
-# download, build, install, and remove cmake-3.14.4
-RUN wget https://cmake.org/files/v3.14/cmake-3.14.4-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.14.4-Linux-x86_64.tar.gz \
-    && cp -r cmake-3.14.4-Linux-x86_64/bin /usr/ \
-    && cp -r cmake-3.14.4-Linux-x86_64/share /usr/ \
-    && cp -r cmake-3.14.4-Linux-x86_64/doc /usr/share/ \
-    && cp -r cmake-3.14.4-Linux-x86_64/man /usr/share/ \
-    && cd $HOME && rm -rf  cmake-3.14.4-Linux-x86_64.tar.gz \
-    && rm -rf cmake-3.14.4-Linux-x86_64
+# download, build, install, and remove cmake-3.17.1
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-Linux-x86_64.tar.gz \
+    && wget https://github.com/Kitware/CMake/releases/download/v3.17.1/cmake-3.17.1-SHA-256.txt \
+    && cat cmake-3.17.1-SHA-256.txt | grep cmake-3.17.1-Linux-x86_64.tar.gz | sha256sum --check \
+    && tar -xzf cmake-3.17.1-Linux-x86_64.tar.gz \
+    && cp -r cmake-3.17.1-Linux-x86_64/bin /usr/ \
+    && cp -r cmake-3.17.1-Linux-x86_64/share /usr/ \
+    && cp -r cmake-3.17.1-Linux-x86_64/doc /usr/share/ \
+    && cp -r cmake-3.17.1-Linux-x86_64/man /usr/share/ \
+    && cd $HOME && rm -rf  cmake-3.17.1-Linux-x86_64.tar.gz \
+    && rm -rf cmake-3.17.1-Linux-x86_64
 
 # install nice-to-have some dev tools
 RUN apt-get -y update && apt-get -y upgrade && apt-get install -q -y \
@@ -298,6 +305,38 @@ RUN apt-get -y update && apt-get -y upgrade && apt-get install -q -y \
     tig \
     tmux \
     tree \
+    git-extras \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install scikit-image \
+    && cd $HOME && git clone https://github.com/cocodataset/cocoapi.git \
+    && cd cocoapi/PythonAPI \
+    && python3 setup.py install
+
+RUN apt-get -y update && apt-get -y upgrade && apt-get install --reinstall -q -y \
+    python*-decorator \
+    doxygen \
+    python3-sphinx \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m pip install --upgrade sphinx
+
+RUN python3 -m pip install sphinx_rtd_theme \
+    breathe \
+    pyserial
+
+RUN cd $HOME && git clone https://github.com/google/protobuf.git \
+    && cd protobuf && git submodule update --init --recursive \
+    && ./autogen.sh \
+    && ./configure \
+    && make && make check && make install && ldconfig
+
+RUN cd $HOME && rm -rf protobuf
+
+RUN python3 -m pip install pyyaml -I && python3 -m pip install scipy -I
+
+RUN apt-get -y update && apt-get install git-lfs -y \
+    && git lfs install \
     && rm -rf /var/lib/apt/lists/*
 
 # Taken from - https://docs.docker.com/engine/examples/running_ssh_service/#environment-variables

--- a/publish_docker_images.sh
+++ b/publish_docker_images.sh
@@ -1,41 +1,66 @@
 #!/bin/bash
-publish_bionic () {
+publish_cpu_date () {
     date_string=`date +"%Y%m%d"`
-    bionic_sha=$(docker images | grep "^drake-torch[[:space:]]*bionic" | awk '{print $3}')
-    if [[ -z $date_string || -z $bionic_sha ]]; then
-        echo "date $date_string or sha $bionic_sha is empty"
+    cpu_sha=$(docker images | grep "^drake-torch[[:space:]]*cpu " | awk '{print $3}')
+    if [[ -z $date_string || -z $cpu_sha ]]; then
+        echo "date $date_string or sha $cpu_sha is empty"
     else
-        echo "tagging $bionic_sha as ubuntu/bionic_$date_string" 
-        docker tag $bionic_sha dexai2/drake-torch:bionic_$date_string
-        docker tag $bionic_sha dexai2/drake-torch:bionic_latest
-        docker push dexai2/drake-torch:bionic_$date_string
-        docker push dexai2/drake-torch:bionic_latest
+        echo "tagging $cpu_sha as dexai2/drake-torch:cpu_$date_string"
+        docker tag $cpu_sha dexai2/drake-torch:cpu_$date_string
+        # docker push dexai2/drake-torch:cpu_$date_string
     fi
 }
-publish_cuda () {
+publish_cpu_latest () {
+    cpu_sha=$(docker images | grep "^drake-torch[[:space:]]*cpu " | awk '{print $3}')
+    if [[ -z $cpu_sha ]]; then
+        echo "sha $cpu_sha is empty"
+    else
+        docker tag $cpu_sha dexai2/drake-torch:cpu_latest
+        docker push dexai2/drake-torch:cpu_latest
+    fi
+}
+publish_cuda_date () {
     date_string=`date +"%Y%m%d"`
-    cuda_sha=$(docker images | grep "^drake-torch[[:space:]]*cuda" | awk '{print $3}')
+    cuda_sha=$(docker images | grep "^drake-torch[[:space:]]*cuda " | awk '{print $3}')
     if [[ -z $date_string || -z $cuda_sha ]]; then
         echo "date $date_string or sha $cuda_sha is empty"
     else
-        echo "tagging $cuda_sha as dexai2/drake-torch:cuda_$date_string" 
+        echo "tagging $cuda_sha as dexai2/drake-torch:cuda_$date_string"
         docker tag $cuda_sha dexai2/drake-torch:cuda_$date_string
+        # docker push dexai2/drake-torch:cuda_$date_string
+    fi
+}
+publish_cuda_latest () {
+    cuda_sha=$(docker images | grep "^drake-torch[[:space:]]*cuda " | awk '{print $3}')
+    if [[ -z $cuda_sha ]]; then
+        echo "sha $cuda_sha is empty"
+    else
         docker tag $cuda_sha dexai2/drake-torch:cuda_latest
-        docker push dexai2/drake-torch:cuda_$date_string
         docker push dexai2/drake-torch:cuda_latest
     fi
 }
 if [[ $# -eq 0 ]]; then
-    echo "no arguments supplied, defaulting to publishing both bionic and cuda"
-    publish_bionic
-    publish_cuda
-elif [[ $* == *--bionic* ]]; then
-    echo "Ubuntu Bionic specified:"
-    publish_bionic
+    echo "no arguments supplied, defaulting to publishing dated versions of cpu and cuda"
+    publish_cpu_date
+    publish_cuda_date
+elif [[ $* == *--cpu* || $* == *--bionic* ]]; then
+    echo "Ubuntu cpu specified, publishing dated version:"
+    publish_cpu_date
+    if [[ $* == *--latest* ]]; then
+        publish_cpu_latest
+    fi
 elif [[ $* == *--cuda* ]]; then
-    echo "CUDA specified:"
-    publish_cuda
+    echo "CUDA specified, publishing dated version:"
+    publish_cuda_date
+    if [[ $* == *--latest* ]]; then
+        publish_cuda_latest
+    fi
+elif [[ $* == *--latest* && ( $* != *--cuda* && $* != *--cpu* ) ]]; then
+    echo "only --latest specified, publishing latest cpu and cuda version:"
+    publish_cpu_date
+    publish_cuda_date
+    publish_cpu_latest
+    publish_cuda_latest
 else
-    echo "need to specify --cuda --ubuntu (or no arguments, defaults to both ubuntu/bionic and cuda)"
+    echo "need to specify --cuda --cpu (or no arguments, defaults to both cpu and cuda); add --latest to also update the latest tag"
 fi
-

--- a/run_docker_tests.sh
+++ b/run_docker_tests.sh
@@ -1,0 +1,19 @@
+
+#! /bin/bash
+echo "Testing Drake-Torch Docker containers..."
+docker run -it drake-torch:cuda_test
+cuda_test_result=$(echo $?)
+if [[ $cuda_test_result != 0  ]]; then
+    echo "test_installation.py=$cuda_test_result; test failed for drake-torch:cuda!"
+    exit 1
+else
+    echo "test_installation.py=$cuda_test_result; test passed for drake-torch:cuda!"
+fi
+docker run -it drake-torch:cpu_test
+cpu_test_result=$(echo $?)
+if [[ $cpu_test_result != 0  ]]; then
+    echo "test_installation.py=$cpu_test_result; test failed for drake-torch:cpu!"
+    exit 2
+else
+    echo "test_installation.py=$cpu_test_result; test passed for drake-torch:cpu!"
+fi

--- a/scripts/fix_bashrc.sh
+++ b/scripts/fix_bashrc.sh
@@ -5,6 +5,7 @@ set -euf -o pipefail
 declare ORIGINAL=' \[ -z "$PS1" \] && return '
 ORIGINAL="${ORIGINAL// /[[:space:]]*}"
 
+# need to source bashrc in a non-interactive shell to get paths correct
 declare REPLACEMENT='case $- in
     *i*) ;;
       *) return;;
@@ -24,6 +25,9 @@ if ! grep -q functools.reduce /opt/ros/melodic/lib/python2.7/dist-packages/messa
     sed -i -e 's/reduce/functools.reduce/g' /opt/ros/melodic/lib/python2.7/dist-packages/message_filters/__init__.py
 fi
 
+# TODO: fix up these calls into functions
+# TODO: move this code into a separate setup script which can be sourced
+
 cat <<'EOF' >> /root/.bashrc
 if [[ -f /opt/ros/$ROS_DISTRO/setup.bash ]]; then
     echo "found /opt/ros/$ROS_DISTRO/setup.bash. sourcing..."
@@ -38,7 +42,9 @@ export ROS_PYTHON_VERSION=3
 # this always needs to be first in the path
 export PYTHONPATH=/opt/ros/melodic/lib/python3/dist-packages/:$PYTHONPATH
 
-if ! grep -q /opt/drake/lib/python3.6/site-packages <<< "$PYTHONPATH"; then 
+if ! grep -q /opt/drake/lib/python3.6/site-packages <<< "$PYTHONPATH"; then
     export PYTHONPATH=$PYTHONPATH:/opt/drake/lib/python3.6/site-packages
 fi
+
+export PS1="\[\033[36m\]\u\[\033[m\]@\[\033[32m\] \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) \$ "
 EOF

--- a/test_python.dockerfile
+++ b/test_python.dockerfile
@@ -1,0 +1,5 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+SHELL ["/bin/bash", "-c"]
+COPY tests/test_installation.py $HOME
+CMD export PYTHONPATH=$PYTHONPATH:/opt/drake/lib/python3.6/site-packages && python3 test_installation.py

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash --init-file
+PS1='$ '
+source /root/.bashrc
+result=$(python3 test_installation.py)
+# echo $result

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -1,0 +1,15 @@
+import unittest
+import pydrake
+import torch
+
+class TestPydrakeInstall(unittest.TestCase):
+    def test_drake_path(self):
+        """
+        Test that the drake path is not empty
+        """
+        self.assertEqual(len(pydrake.getDrakePath()), 22)
+
+if __name__ == '__main__':
+    print("before unit test")
+    unittest.main(exit=True)
+    # print("result of unittest.main", result)


### PR DESCRIPTION
In order to provide up-to-date builds for `drake` and `pytorch` for both `cpu` and `gpu` machines, we have made the following changes:
- [x] single build script which takes flags for `./build.sh --cpu` or `./build.sh --gpu` which triggers which version of `pytorch` will be downloaded and installed
- [x] upgraded to `cmake-3.17.1` and perform checksum verification
- [x] `test_docker_images.sh` builds `drake-torch-cpu-test` and `drake-torch-gpu-test` and verifies that `tests/test_installation.py` correctly runs
- [x] `publish_docker_images.sh` publishes both `cpu` and `gpu` versions to docker-hub