### PR TITLE
gcc 10, reduced apt-get update calls

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,5 +48,6 @@ else
   TAG="dexai2/drake-torch:cuda"
 fi
 
+# --no-cache 
 echo "building drake-torch image, build type: $BUILD_TYPE, base image: $BASE_IMAGE, channel: $BUILD_CHANNEL"
-docker build -f drake-torch.dockerfile --no-cache --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BUILD_CHANNEL=$BUILD_CHANNEL -t $TAG --cpuset-cpus "0-$LASTCORE" . > /dev/stderr
+docker build -f drake-torch.dockerfile --build-arg BUILD_TYPE=$BUILD_TYPE --build-arg BASE_IMAGE=$BASE_IMAGE --build-arg BUILD_CHANNEL=$BUILD_CHANNEL -t $TAG --cpuset-cpus "0-$LASTCORE" . > /dev/stderr

--- a/build.sh
+++ b/build.sh
@@ -43,7 +43,7 @@ else
   if [[ $BUILD_CHANNEL == 'stable' ]]; then
     BASE_IMAGE="nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04"
   else
-    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04-rc"
+    BASE_IMAGE="nvidia/cuda:11.0-cudnn8-devel-ubuntu18.04"
   fi
   TAG="dexai2/drake-torch:cuda"
 fi

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -53,8 +53,8 @@ RUN set -eux \
         apt-utils \
         openssh-server \
         curl \
-        gcc-9 \
-        g++-9 \
+        gcc-8 \
+        g++-8 \
         gcc-10 \
         g++-10 \
         cmake \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -72,7 +72,7 @@ RUN set -eux \
         xz-utils \
         libgflags-dev \
         libgoogle-glog-dev \
-        libgtest-dev \
+        # libgtest-dev \
         libhidapi-dev \
         libiomp-dev \
         libopenmpi-dev \
@@ -92,10 +92,17 @@ RUN python3 -m pip install --upgrade --no-cache-dir --compile \
         setuptools wheel pip
 
 # gtest per recommended method
-RUN set -eux \
-    && mkdir ~/gtest && cd ~/gtest && cmake /usr/src/gtest && make \
-    && cp *.a /usr/local/lib \
-    && cd $HOME && rm -rf gtest
+RUN cd $HOME \
+    && wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
+    && tar xzf release-1.10.0.tar.gz \
+    && cd googletest-release-1.10.0 \
+    && mkdir build \
+    && cd build \
+    && cmake .. \
+    && make -j \
+    && cp -r ../googletest/include /usr/local/include \
+    && cp lib/*.a /usr/local/lib \
+    && cd $HOME && rm -rf googletest-release-1.10.0
 
 # python packages for toppra, qpOASES, etc.
 RUN python3 -m pip install --upgrade --no-cache-dir --compile \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -22,7 +22,9 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # then update make to the latest version manually as apt is old
 # without the apt install, drake will install old apt version overwriting new one
 
-RUN apt-get update && apt-get install -qy \
+RUN apt-get update \
+    && apt-get upgrade \
+    && apt-get install -qy \
     gnupg2 \
     apt-transport-https \
     ca-certificates \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -27,8 +27,7 @@ RUN apt-get update && apt-get install -qy \
     apt-transport-https \
     ca-certificates \
     software-properties-common \
-    wget \
-    && rm -rf /var/lib/apt/lists/*
+    wget
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
@@ -79,8 +78,7 @@ RUN set -eux \
     protobuf-compiler \
     python3 \
     python3-dev \
-    python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+    python3-pip
 
 RUN update-alternatives \
         --install /usr/bin/gcc gcc /usr/bin/gcc-10 90 \
@@ -138,8 +136,7 @@ RUN python3 -m pip install --upgrade --no-cache-dir --compile \
 RUN wget -q https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB
 RUN apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && rm GPG-PUB*
 RUN sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'
-RUN apt-get update && apt-get -y install intel-mkl-64bit-2019.1-053 \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install intel-mkl-64bit-2019.1-053
 RUN rm /opt/intel/mkl/lib/intel64/*.so
 
 # Download and build libtorch with MKL support
@@ -186,7 +183,6 @@ RUN set -eux \
         else curl -SL https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-bionic.tar.gz | tar -xzC /opt; \
         fi \
     && cd /opt/drake/share/drake/setup && yes | ./install_prereqs \
-    && rm -rf /var/lib/apt/lists/* \
     && cd $HOME && rm -rf drake*bionic.tar.gz
 
 # pip install pydrake using the /opt/drake directory in develop mode
@@ -206,16 +202,13 @@ RUN apt-get update && apt-get install -qy \
     librosconsole-dev \
     libxmlrpcpp-dev \
     lsb-release \
-    libyaml-cpp-dev \
-
-    && rm -rf /var/lib/apt/lists/*
+    libyaml-cpp-dev
 
 # install bootstrap tools
 RUN apt-get install --no-install-recommends -qy \
     python3-rosdep \
     python3-rosinstall \
-    python3-vcstools \
-    && rm -rf /var/lib/apt/lists/*
+    python3-vcstools
 
 # setup environment
 ENV LANG C.UTF-8
@@ -245,8 +238,7 @@ RUN apt-get install -y \
     python-catkin-tools \
     usbutils \
     software-properties-common \
-    iputils-ping \
-    && rm -rf /var/lib/apt/lists/*
+    iputils-ping
 
 # install cv_bridge to /opt/ros/melodic from source
 SHELL ["/bin/bash", "-c"]
@@ -339,8 +331,7 @@ RUN apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE \
     librealsense2-utils \
     librealsense2-dev \
     librealsense2-dbg \
-    librealsense2 \
-    && rm -rf /var/lib/apt/lists/*
+    librealsense2
 
 # install LCM system-wide
 RUN cd $HOME && git clone https://github.com/lcm-proj/lcm \
@@ -358,6 +349,7 @@ RUN cd $HOME && git clone https://github.com/frankaemika/libfranka.git \
 ########################################################
 
 # install nice-to-have some dev tools
+# only clear apt lists at the last apt call
 RUN apt-get install -qy \
     htop \
     nano \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -55,6 +55,8 @@ RUN set -eux \
         curl \
         gcc-8 \
         g++-8 \
+        gcc-9 \
+        g++-9 \
         gcc-10 \
         g++-10 \
         cmake \
@@ -364,11 +366,11 @@ RUN cd $HOME && git clone https://github.com/lcm-proj/lcm \
     && cd $HOME && rm -rf lcm
 
 # install libfranka system-wide, doesn't work with gcc10, so use 9 instead
-RUN cd $HOME && git clone https://github.com/frankaemika/libfranka.git \
+RUN cd $HOME && git clone --recursive https://github.com/frankaemika/libfranka.git \
     && cd libfranka && git checkout 0.8.0 && git submodule update --init \
     && mkdir -p build && cd build \
     && cmake -DCMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=gcc-9 -D CMAKE_CXX_COMPILER=g++-9 .. \
-    && make && make install \
+    && cmake --build . \
     && cd $HOME && rm -rf libfranka
 
 ########################################################

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -54,6 +54,8 @@ RUN set -eux \
     apt-utils \
     openssh-server \
     curl \
+    gcc-9 \
+    g++-9 \
     gcc-10 \
     g++-10 \
     cmake \
@@ -340,10 +342,12 @@ RUN cd $HOME && git clone https://github.com/lcm-proj/lcm \
     && cd lcm && mkdir -p build && cd build && cmake .. && make && make install \
     && cd $HOME && rm -rf lcm
 
-# install libfranka system-wide
+# install libfranka system-wide, doesn't work with gcc10, so use 9 instead
 RUN cd $HOME && git clone https://github.com/frankaemika/libfranka.git \
     && cd libfranka && git checkout 0.8.0 && git submodule update --init \
-    && mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make && make install \
+    && mkdir -p build && cd build \
+    && cmake -DCMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=gcc-9 -D CMAKE_CXX_COMPILER=g++-9 .. \
+    && make && make install \
     && cd $HOME && rm -rf libfranka
 
 ########################################################

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -53,8 +53,6 @@ RUN set -eux \
         apt-utils \
         openssh-server \
         curl \
-        gcc-8 \
-        g++-8 \
         gcc-9 \
         g++-9 \
         gcc-10 \
@@ -74,7 +72,6 @@ RUN set -eux \
         xz-utils \
         libgflags-dev \
         libgoogle-glog-dev \
-        # libgtest-dev \
         libhidapi-dev \
         libiomp-dev \
         libopenmpi-dev \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -41,7 +41,7 @@ RUN add-apt-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' \
     && add-apt-repository ppa:ubuntu-toolchain-r/test -y
 
 # ensure keyring for cmake stays up to date as kitware rotates their keys
-RUN apt-get install kitware-archive-keyring \
+RUN apt-get install -qy kitware-archive-keyring \
     && rm /etc/apt/trusted.gpg.d/kitware.gpg
 
 # setup timezone, install python3 and essential with apt and others with pip
@@ -222,7 +222,7 @@ RUN rosdep init \
 
 # install ros packages
 ENV ROS_DISTRO melodic
-RUN apt-get install -y \
+RUN apt-get install -qy \
     ros-melodic-ros-base \
     ros-melodic-geometry2 \
     libpcl-dev \
@@ -328,7 +328,7 @@ RUN git clone https://github.com/rogersce/cnpy.git \
 RUN apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE \
     || apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C8B3A55A6F3EFCDE \
     && add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo bionic main" -u \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get install -qy \
     librealsense2-dkms \
     librealsense2-utils \
     librealsense2-dev \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -23,13 +23,12 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # without the apt install, drake will install old apt version overwriting new one
 
 RUN apt-get update \
-    && apt-get upgrade -qy \
     && apt-get install -qy \
-    gnupg2 \
-    apt-transport-https \
-    ca-certificates \
-    software-properties-common \
-    wget
+        gnupg2 \
+        apt-transport-https \
+        ca-certificates \
+        software-properties-common \
+        wget
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
 RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
@@ -48,41 +47,41 @@ RUN apt-get install -qy kitware-archive-keyring \
 # Install Protobuf Compiler, asked for by Cmake Find for protobuf. Installation suppresses a warning in cmake.
 # Drake needs protobuf, but not the protobuf compiler, therefore "install_prereqs" does not ask for it.
 RUN set -eux \
-    && echo 'etc/UTC' > /etc/timezone && \
-    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
-    apt-get update && apt-get install -qy \
-    apt-utils \
-    openssh-server \
-    curl \
-    gcc-9 \
-    g++-9 \
-    gcc-10 \
-    g++-10 \
-    cmake \
-    gdb \
-    gdbserver \
-    rsync \
-    git \
-    gzip \
-    jq \
-    vim \
-    tzdata \
-    unzip \
-    x11vnc \
-    xvfb \
-    xz-utils \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libgtest-dev \
-    libhidapi-dev \
-    libiomp-dev \
-    libopenmpi-dev \
-    libudev-dev \
-    libusb-1.0-0-dev \
-    protobuf-compiler \
-    python3 \
-    python3-dev \
-    python3-pip
+    && echo 'etc/UTC' > /etc/timezone \
+    && ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime \
+    && apt-get update && apt-get install -qy \
+        apt-utils \
+        openssh-server \
+        curl \
+        gcc-9 \
+        g++-9 \
+        gcc-10 \
+        g++-10 \
+        cmake \
+        gdb \
+        gdbserver \
+        rsync \
+        git \
+        gzip \
+        jq \
+        vim \
+        tzdata \
+        unzip \
+        x11vnc \
+        xvfb \
+        xz-utils \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libgtest-dev \
+        libhidapi-dev \
+        libiomp-dev \
+        libopenmpi-dev \
+        libudev-dev \
+        libusb-1.0-0-dev \
+        protobuf-compiler \
+        python3 \
+        python3-dev \
+        python3-pip
 
 RUN update-alternatives \
         --install /usr/bin/gcc gcc /usr/bin/gcc-10 90 \
@@ -90,7 +89,7 @@ RUN update-alternatives \
         --slave /usr/bin/gcov gcov /usr/bin/gcov-10
 
 RUN python3 -m pip install --upgrade --no-cache-dir --compile \
-    setuptools wheel pip
+        setuptools wheel pip
 
 # gtest per recommended method
 RUN set -eux \
@@ -100,37 +99,37 @@ RUN set -eux \
 
 # python packages for toppra, qpOASES, etc.
 RUN python3 -m pip install --upgrade --no-cache-dir --compile \
-    typing \
-    decorator \
-    cython \
-    numpy \
-    scipy \
-    defusedxml \
-    empy \
-    nose2 \
-    netifaces \
-    cpppo \
-    pyyaml \
-    pyserial \
-    pyzmq \
-    pyside2 \
-    msgpack \
-    rospkg \
-    mkl \
-    mkl-include \
-    cffi \
-    ecos \
-    tqdm \
-    visdom \
-    scikit-image \
-    opencv-python \
-    munch \
-    supervisor \
-    sphinx \
-    sphinx_rtd_theme \
-    breathe \
-    jupyterlab \
-    import-ipynb
+        typing \
+        decorator \
+        cython \
+        numpy \
+        scipy \
+        defusedxml \
+        empy \
+        nose2 \
+        netifaces \
+        cpppo \
+        pyyaml \
+        pyserial \
+        pyzmq \
+        pyside2 \
+        msgpack \
+        rospkg \
+        mkl \
+        mkl-include \
+        cffi \
+        ecos \
+        tqdm \
+        visdom \
+        scikit-image \
+        opencv-python \
+        munch \
+        supervisor \
+        sphinx \
+        sphinx_rtd_theme \
+        breathe \
+        jupyterlab \
+        import-ipynb
 
 
 ##############################################################
@@ -201,18 +200,18 @@ RUN python3 -m pip install -e /opt/drake/lib/python3.6/site-packages
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -sc` main" > /etc/apt/sources.list.d/ros-latest.list
 
 # install needed ROS packages
-RUN apt-get update && apt-get install -qy \
-    dirmngr \
-    librosconsole-dev \
-    libxmlrpcpp-dev \
-    lsb-release \
-    libyaml-cpp-dev
+    RUN apt-get update && apt-get install -qy \
+        dirmngr \
+        librosconsole-dev \
+        libxmlrpcpp-dev \
+        lsb-release \
+        libyaml-cpp-dev
 
 # install bootstrap tools
 RUN apt-get install --no-install-recommends -qy \
-    python3-rosdep \
-    python3-rosinstall \
-    python3-vcstools
+        python3-rosdep \
+        python3-rosinstall \
+        python3-vcstools
 
 # setup environment
 ENV LANG C.UTF-8
@@ -225,24 +224,24 @@ RUN rosdep init \
 # install ros packages
 ENV ROS_DISTRO melodic
 RUN apt-get install -qy \
-    ros-melodic-ros-base \
-    ros-melodic-geometry2 \
-    libpcl-dev \
-    ros-melodic-pcl-ros \
-    libopencv-dev \
-    ros-melodic-vision-opencv \
-    ros-melodic-xacro \
-    ros-melodic-rospy-message-converter \
-    ros-melodic-image-transport \
-    ros-melodic-rgbd-launch \
-    ros-melodic-ddynamic-reconfigure \
-    ros-melodic-diagnostic-updater \
-    ros-melodic-robot-state-publisher \
-    ros-melodic-joint-state-publisher \
-    python-catkin-tools \
-    usbutils \
-    software-properties-common \
-    iputils-ping
+        ros-melodic-ros-base \
+        ros-melodic-geometry2 \
+        libpcl-dev \
+        ros-melodic-pcl-ros \
+        libopencv-dev \
+        ros-melodic-vision-opencv \
+        ros-melodic-xacro \
+        ros-melodic-rospy-message-converter \
+        ros-melodic-image-transport \
+        ros-melodic-rgbd-launch \
+        ros-melodic-ddynamic-reconfigure \
+        ros-melodic-diagnostic-updater \
+        ros-melodic-robot-state-publisher \
+        ros-melodic-joint-state-publisher \
+        python-catkin-tools \
+        usbutils \
+        software-properties-common \
+        iputils-ping
 
 # install cv_bridge to /opt/ros/melodic from source
 SHELL ["/bin/bash", "-c"]
@@ -251,9 +250,9 @@ RUN cd $HOME && mkdir -p py3_ws/src && cd py3_ws/src \
     && git clone -b melodic-devel https://github.com/ros/ros_comm.git \
     && cd $HOME/py3_ws \
     && python3 -m pip install --upgrade --no-cache-dir --compile \
-    catkin_tools \
-    pycryptodomex \
-    gnupg \
+        catkin_tools \
+        pycryptodomex \
+        gnupg \
     && source /opt/ros/melodic/setup.bash \
     && export ROS_PYTHON_VERSION=3 \
     && catkin config --install \
@@ -331,11 +330,11 @@ RUN apt-key adv --keyserver keys.gnupg.net --recv-key C8B3A55A6F3EFCDE \
     || apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C8B3A55A6F3EFCDE \
     && add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo bionic main" -u \
     && apt-get update && apt-get install -qy \
-    librealsense2-dkms \
-    librealsense2-utils \
-    librealsense2-dev \
-    librealsense2-dbg \
-    librealsense2
+        librealsense2-dkms \
+        librealsense2-utils \
+        librealsense2-dev \
+        librealsense2-dbg \
+        librealsense2
 
 # install LCM system-wide
 RUN cd $HOME && git clone https://github.com/lcm-proj/lcm \
@@ -356,19 +355,20 @@ RUN cd $HOME && git clone https://github.com/frankaemika/libfranka.git \
 
 # install nice-to-have some dev tools
 # only clear apt lists at the last apt call
-RUN apt-get install -qy \
-    htop \
-    nano \
-    tig \
-    tmux \
-    tree \
-    git-extras \
-    clang-format-8 \
-    espeak-ng-espeak \
-    iwyu \
-    ros-melodic-tf-conversions \
-    git-lfs \
-    doxygen \
+RUN apt-get upgrade -qy \
+    && apt-get install -qy \
+        htop \
+        nano \
+        tig \
+        tmux \
+        tree \
+        git-extras \
+        clang-format-8 \
+        espeak-ng-espeak \
+        iwyu \
+        ros-melodic-tf-conversions \
+        git-lfs \
+        doxygen \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git lfs install

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -23,7 +23,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # without the apt install, drake will install old apt version overwriting new one
 
 RUN apt-get update \
-    && apt-get upgrade -y \
+    && apt-get upgrade -qy \
     && apt-get install -qy \
     gnupg2 \
     apt-transport-https \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -340,7 +340,7 @@ RUN cd $HOME && git clone https://github.com/lcm-proj/lcm \
 
 # install libfranka system-wide
 RUN cd $HOME && git clone https://github.com/frankaemika/libfranka.git \
-    && cd libfranka && git checkout 0.5.0 && git submodule update --init \
+    && cd libfranka && git checkout 0.8.0 && git submodule update --init \
     && mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make && make install \
     && cd $HOME && rm -rf libfranka
 

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -91,18 +91,33 @@ RUN update-alternatives \
 RUN python3 -m pip install --upgrade --no-cache-dir --compile \
         setuptools wheel pip
 
-# gtest per recommended method
+# gtest per recommended method, needed by msgpack etc.
 RUN cd $HOME \
-    && wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
-    && tar xzf release-1.10.0.tar.gz \
-    && cd googletest-release-1.10.0 \
-    && mkdir build \
-    && cd build \
-    && cmake .. \
-    && make -j \
-    && cp -r ../googletest/include /usr/local/include \
-    && cp lib/*.a /usr/local/lib \
-    && cd $HOME && rm -rf googletest-release-1.10.0
+    && \
+        if [ $BUILD_CHANNEL = "stable" ] ; \
+        then \
+            wget -q https://github.com/google/googletest/archive/release-1.8.1.tar.gz \
+            && tar -xzf release-1.8.1.tar.gz \
+            && cd googletest-release-1.8.1 \
+            && mkdir build \
+            && cd build \
+            && cmake .. \
+            && make -j \
+            && cp -r ../googletest/include /usr/local/include \
+            && cp googlemock/gtest/*.a /usr/local/lib \
+            && cd $HOME && rm -rf googletest-release-1.8.1 release-1.8.1.tar.gz; \
+        else \
+            wget -q https://github.com/google/googletest/archive/release-1.10.0.tar.gz \
+            && tar -xzf release-1.10.0.tar.gz \
+            && cd googletest-release-1.10.0 \
+            && mkdir build \
+            && cd build \
+            && cmake .. \
+            && make -j \
+            && cp -r ../googletest/include /usr/local/include \
+            && cp lib/*.a /usr/local/lib \
+            && cd $HOME && rm -rf googletest-release-1.10.0 release-1.10.0.tar.gz; \
+        fi
 
 # python packages for toppra, qpOASES, etc.
 RUN python3 -m pip install --upgrade --no-cache-dir --compile \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -23,7 +23,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 # without the apt install, drake will install old apt version overwriting new one
 
 RUN apt-get update \
-    && apt-get upgrade \
+    && apt-get upgrade -y \
     && apt-get install -qy \
     gnupg2 \
     apt-transport-https \


### PR DESCRIPTION
> Drake needs protobuf, but not the protobuf compiler, therefore "install_prereqs" does not ask for it.

* [x] Above comment is no longer true. `protobuf` has been removed for over a month without issue.
* [x] default gcc and g++ 10
* [x] This branch passed Jenkins pipeline and was tested on robot.

![image](https://user-images.githubusercontent.com/865317/88998999-58e2c880-d2c1-11ea-9064-3748f927a26b.png)
