### PR TITLE
Remove libfranka systemwide install from docker image

### DIFF
--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -362,14 +362,6 @@ RUN cd $HOME && git clone https://github.com/lcm-proj/lcm \
     && cd lcm && mkdir -p build && cd build && cmake .. && make && make install \
     && cd $HOME && rm -rf lcm
 
-# install libfranka system-wide, doesn't work with gcc10, so use 9 instead
-RUN cd $HOME && git clone --recursive https://github.com/frankaemika/libfranka.git \
-    && cd libfranka && git checkout 0.8.0 && git submodule update --init \
-    && mkdir -p build && cd build \
-    && cmake -DCMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=gcc-9 -D CMAKE_CXX_COMPILER=g++-9 .. \
-    && cmake --build . \
-    && cd $HOME && rm -rf libfranka
-
 ########################################################
 # Essential packages for remote debugging and login in
 ########################################################


### PR DESCRIPTION
I'm not sure why this was ever in here, but to build `drake-franka-driver` we have it as an external submodule anyways so this isn't needed here