### PR TITLE
add pyrealsense2 and pyusb to image

### DIFF
--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -172,8 +172,8 @@ RUN python3 -m pip install --upgrade --no-cache-dir --compile \
         sphinx \
         sphinx_rtd_theme \
         click \
-        pyrealsense2==2.38.1.2225 \
-        pyusb==1.0.2
+        pyrealsense2>=2.38.1.2225 \
+        pyusb>=1.0.2
 
 # OpenCV 4.4.0 release library (for C++ and Python)
 RUN apt-get install -qy \

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -171,7 +171,9 @@ RUN python3 -m pip install --upgrade --no-cache-dir --compile \
         supervisor \
         sphinx \
         sphinx_rtd_theme \
-        click
+        click \
+        pyrealsense2==2.38.1.2225 \
+        pyusb==1.0.2
 
 # OpenCV 4.4.0 release library (for C++ and Python)
 RUN apt-get install -qy \


### PR DESCRIPTION
we might consider adding version numbers to the other dependencies as well. it's only a matter of time until our docker image pulls a breaking change from one of these dependencies