### PR TITLE
Split prompt based on DEPLOYMENT_DOCKER env variable, more pretty

### DIFF
--- a/scripts/fix_bashrc.sh
+++ b/scripts/fix_bashrc.sh
@@ -45,7 +45,7 @@ export PYTHONPATH=$PYTHONPATH:/opt/ros/melodic/lib/python2.7/dist-packages/
 
 # set prompt text/color based on type of container
 if [[ ! -v DEPLOYMENT_DOCKER ]]; then 
-	export PS1="🐳  \[\033[36m\]\h\[\033[32m\] (dev) \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) \$ "
+	export PS1="🐳  \[\033[36m\]\h\[\033[32m\] (dev) \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) "
 else
 	export PS1='🐳  \[\033[36m\]\h\[\e[0;49;91m\] (deploy) \[\033[33;1m\]\w\[\033[m\] '
 fi

--- a/scripts/fix_bashrc.sh
+++ b/scripts/fix_bashrc.sh
@@ -42,5 +42,12 @@ export ROS_PYTHON_VERSION=3
 # prioritise python3 imports, then python2, apt installs to python2
 export PYTHONPATH=/opt/ros/melodic/lib/python3/dist-packages/:$PYTHONPATH
 export PYTHONPATH=$PYTHONPATH:/opt/ros/melodic/lib/python2.7/dist-packages/
-export PS1="\[\033[36m\]\u\[\033[m\]@\[\033[32m\] \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) \$ "
+
+# set prompt text/color based on type of container
+if [[ ! -v DEPLOYMENT_DOCKER ]]; then 
+	export PS1="🐳  \[\033[36m\]\h\[\033[32m\] dev \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) \$ "
+else
+	export PS1='🐳  \[\033[36m\]\h\[\e[0;49;91m\] deploy \[\033[33;1m\]\w\[\033[m\] '
+fi
+"
 EOF

--- a/scripts/fix_bashrc.sh
+++ b/scripts/fix_bashrc.sh
@@ -45,9 +45,9 @@ export PYTHONPATH=$PYTHONPATH:/opt/ros/melodic/lib/python2.7/dist-packages/
 
 # set prompt text/color based on type of container
 if [[ ! -v DEPLOYMENT_DOCKER ]]; then 
-	export PS1="🐳  \[\033[36m\]\h\[\033[32m\] dev \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) \$ "
+	export PS1="🐳  \[\033[36m\]\h\[\033[32m\] (dev) \[\033[33;1m\]\w\[\033[m\] (\$(git branch 2>/dev/null | grep '^*' | colrm 1 2)) \$ "
 else
-	export PS1='🐳  \[\033[36m\]\h\[\e[0;49;91m\] deploy \[\033[33;1m\]\w\[\033[m\] '
+	export PS1='🐳  \[\033[36m\]\h\[\e[0;49;91m\] (deploy) \[\033[33;1m\]\w\[\033[m\] '
 fi
 "
 EOF


### PR DESCRIPTION
If `DEPLOYMENT_DOCKER` env var is set, the top version of the prompt will display. If not, the bottom version will

![image](https://user-images.githubusercontent.com/10868851/92736053-eba66680-f347-11ea-9b21-20c9d037caa8.png)
