### PR TITLE
Sw.tag and push

### DIFF
--- a/publish_docker_images.sh
+++ b/publish_docker_images.sh
@@ -11,18 +11,18 @@
 REPOSITORY=drake-torch
 SUFFIX_DATE=$(date +"%Y%m%d")
 
-OPT_CPU=false
-OPT_CUDA=false
+OPT_CPU=true
+OPT_CUDA=true
 
 # Parse any arguments.
 while (( $# )); do
   case "$1" in
     --cpu)
-      OPT_CPU=true
+      OPT_CUDA=false
       shift 1
       ;;
     --cuda)
-      OPT_CUDA=true
+      OPT_CPU=false
       shift 1
       ;;
     -r|--repo)

--- a/publish_docker_images.sh
+++ b/publish_docker_images.sh
@@ -50,11 +50,11 @@ REPO_STR="dexai2/${REPOSITORY}"
 tag_and_push() {
     BUILD_TYPE=$1
     SUFFIX=$2
-    echo "tagging and pushing image, build type $BUILD_TYPE, suffix $SUFFIX"
+    echo "tagging and pushing image to dexai2/$REPOSITORY, build type $BUILD_TYPE, suffix $SUFFIX"
     CURRENT_TAG=$REPO_STR:$BUILD_TYPE
     NEW_TAG=$REPO_STR:"${BUILD_TYPE}_${SUFFIX}"
-    echo docker tag $CURRENT_TAG $NEW_TAG
-    echo docker push $NEW_TAG
+    docker tag $CURRENT_TAG $NEW_TAG
+    docker push $NEW_TAG
 }
 
 if [[ $OPT_CPU == true ]]; then

--- a/publish_docker_images.sh
+++ b/publish_docker_images.sh
@@ -7,8 +7,45 @@
 # dexai2/drake-torch:cuda -> dexai2/drake-torch:cuda_YYMMDD
 #                         -> dexai2/drake-torch:cuda_latest
 
-REPO_STR=dexai2/drake-torch
+
+REPOSITORY=drake-torch
 SUFFIX_DATE=$(date +"%Y%m%d")
+
+OPT_CPU=false
+OPT_CUDA=false
+
+# Parse any arguments.
+while (( $# )); do
+  case "$1" in
+    --cpu)
+      OPT_CPU=true
+      shift 1
+      ;;
+    --cuda)
+      OPT_CUDA=true
+      shift 1
+      ;;
+    -r|--repo)
+      shift 1
+      REPOSITORY="$1"
+      shift 1
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    -*|--*=) # unsupported options
+      echo "Error: Unsupported option $1" >&2
+      exit 1
+      ;;
+    *) # positional arg -- in this case, path to src directory
+      SRC_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+REPO_STR="dexai2/${REPOSITORY}"
 
 tag_and_push() {
     BUILD_TYPE=$1
@@ -16,12 +53,15 @@ tag_and_push() {
     echo "tagging and pushing image, build type $BUILD_TYPE, suffix $SUFFIX"
     CURRENT_TAG=$REPO_STR:$BUILD_TYPE
     NEW_TAG=$REPO_STR:"${BUILD_TYPE}_${SUFFIX}"
-    docker tag $CURRENT_TAG $NEW_TAG
-    docker push $NEW_TAG
+    echo docker tag $CURRENT_TAG $NEW_TAG
+    echo docker push $NEW_TAG
 }
 
-
-tag_and_push cpu $SUFFIX_DATE
-tag_and_push cpu latest
-tag_and_push cuda $SUFFIX_DATE
-tag_and_push cuda latest
+if [[ $OPT_CPU == true ]]; then
+    tag_and_push cpu $SUFFIX_DATE
+    tag_and_push cpu latest
+fi
+if [[ $OPT_CUDA == true ]]; then
+    tag_and_push cuda $SUFFIX_DATE
+    tag_and_push cuda latest
+fi


### PR DESCRIPTION
Update `publish_docker_images.sh` to take command line arguments.
Defaults to pushing both cuda and cpu images.

Usage examples:
```
$ publish_docker_images.sh 
tagging and pushing image to dexai2/drake-torch, build type cpu, suffix 20200923
tagging and pushing image to dexai2/drake-torch, build type cpu, suffix latest
tagging and pushing image to dexai2/drake-torch, build type cuda, suffix 20200923
tagging and pushing image to dexai2/drake-torch, build type cuda, suffix latest
```
pushes latest to `drake-torch`

```
$ publish_docker_images.sh -r other_repo --cuda
tagging and pushing image to dexai2/other_repo, build type cuda, suffix 20200923
tagging and pushing image to dexai2/other_repo, build type cuda, suffix latest
```
pushes latest to `other_repo`