### PR TITLE
define DRAKE_RESOURCE_ROOT in bashrc to suppress spam

### DIFF
--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -183,7 +183,7 @@ RUN if [ "`lsb_release -sc`" = "bionic" ]; \
 RUN echo 'export DRAKE_RESOURCE_ROOT=/opt/drake/share' >> ~/.bashrc 
 
 # drake installs some python packages as dependencies, causing jupyter issues
-RUN apt remove python3-zmq python3-terminado python3-yaml -qy \
+RUN apt-get remove -qy python3-zmq python3-terminado python3-yaml \
     && python3 -m pip install \
         --upgrade --no-cache-dir --compile \
         ipython ipykernel jupyterlab matplotlib cython pyyaml

--- a/drake-torch.dockerfile
+++ b/drake-torch.dockerfile
@@ -178,6 +178,10 @@ RUN if [ "`lsb_release -sc`" = "bionic" ]; \
         && python3 -m pip install -e /opt/drake/lib/python3.8/site-packages; \
     fi
 
+# get rid of the following spam
+# FindResource ignoring DRAKE_RESOURCE_ROOT because it is not set.
+RUN echo 'export DRAKE_RESOURCE_ROOT=/opt/drake/share' >> ~/.bashrc 
+
 # drake installs some python packages as dependencies, causing jupyter issues
 RUN apt remove python3-zmq python3-terminado python3-yaml -qy \
     && python3 -m pip install \


### PR DESCRIPTION
`FindResource ignoring DRAKE_RESOURCE_ROOT because it is not set.` spam at debug level